### PR TITLE
Use hook_cfg for hooks and add VGG16 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,5 +38,10 @@ def resnet50_model(device: torch.device) -> AttackModel:
 
 
 @pytest.fixture()
+def vgg16_model(device: torch.device) -> AttackModel:
+    return AttackModel.from_pretrained('vgg16', device)
+
+
+@pytest.fixture()
 def vitb16_model(device: torch.device) -> AttackModel:
     return AttackModel.from_pretrained('vit_base_patch16_224', device, from_timm=True)

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -17,11 +17,23 @@ def run_attack_test(attack_cls, device, model, x, y):
 
 @pytest.mark.parametrize(
     'attack_cls',
-    (torchattack.GRADIENT_NON_VIT_ATTACKS | torchattack.NON_EPS_ATTACKS).keys(),
+    [
+        attack
+        for attack in (
+            torchattack.GRADIENT_NON_VIT_ATTACKS | torchattack.NON_EPS_ATTACKS
+        )
+        if attack != 'DR'
+    ],
 )
 def test_common_attacks(attack_cls, device, resnet50_model, data):
     x, y = data(resnet50_model.transform)
     run_attack_test(attack_cls, device, resnet50_model, x, y)
+
+
+# DR attack requires a non-ResNet-50 model
+def test_dr_attack(device, vgg16_model, data):
+    x, y = data(vgg16_model.transform)
+    run_attack_test(torchattack.DR, device, vgg16_model, x, y)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_create_attack.py
+++ b/tests/test_create_attack.py
@@ -5,7 +5,8 @@ from torchattack import create_attack
 
 
 @pytest.mark.parametrize(
-    ('attack_name', 'expected'), torchattack.GRADIENT_NON_VIT_ATTACKS.items()
+    ('attack_name', 'expected'),
+    [i for i in torchattack.GRADIENT_NON_VIT_ATTACKS.items() if i[0] != 'DR'],
 )
 def test_create_non_vit_attack_same_as_imported(
     attack_name,
@@ -14,6 +15,15 @@ def test_create_non_vit_attack_same_as_imported(
 ):
     created_attacker = create_attack(attack_name, resnet50_model)
     expected_attacker = expected(resnet50_model)
+    assert created_attacker == expected_attacker
+
+
+def test_create_dr_attack_same_as_imported(
+    vgg16_model,
+    data,
+):
+    created_attacker = create_attack('DR', vgg16_model)
+    expected_attacker = torchattack.DR(vgg16_model)
     assert created_attacker == expected_attacker
 
 


### PR DESCRIPTION
Replace model_name with hook_cfg for identifying hooks and introduce a VGG16 model fixture along with tests for the DR attack.