### PR TITLE
Update documentation and refactor attack creation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ attack = create_attack('PGD', model, normalize, device, eps=0.03)
 
 # Initialize MI-FGSM attack with extra args with create_attack
 attack_args = {'steps': 10, 'decay': 1.0}
-attack = create_attack('MIFGSM', model, normalize, device, eps=0.03, attack_args=attack_args)
+attack = create_attack('MIFGSM', model, normalize, device, eps=0.03, **attack_args)
 ```
 
 Check out [`torchattack.eval.runner`](torchattack/eval/runner.py) for a full example.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ pip install torchattack
 - 📊 Tooling for fooling rate metrics and model evaluation in `eval`.
 - 🔁 Numerous attacks reimplemented for readability and efficiency (TGR, VDC, etc.).
 
+## Documentation
+
+torchattack's docs are available at [docs.swo.moe/torchattack](https://docs.swo.moe/torchattack/).
+
 ## Usage
 
 ```python
@@ -79,7 +83,7 @@ attack_args = {'steps': 10, 'decay': 1.0}
 attack = create_attack('MIFGSM', model, normalize, device, eps=0.03, **attack_args)
 ```
 
-Check out [`torchattack.eval.runner`](torchattack/eval/runner.py) for a full example.
+Check out [examples/](examples/mifgsm_transfer.py) and [`torchattack.eval.runner`](torchattack/eval/runner.py) for full examples.
 
 ## Attacks
 
@@ -266,21 +270,7 @@ Check out [`torchattack.eval.runner`](torchattack/eval/runner.py) for a full exa
 
 ## Development
 
-uv is used for development.
-
-First, [install uv](https://docs.astral.sh/uv/getting-started/installation/).
-
-Next, install dev dependencies.
-
-```shell
-uv sync --dev
-```
-
-Install dependency group `test` to run tests.
-
-```shell
-uv sync --dev --group test
-```
+On how to install dependencies, run tests, and build documentation. See [Development - torchattack](https://docs.swo.moe/torchattack/development/).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 title: Home
 hide:
   - navigation
+  - toc
   - footer
 ---
 

--- a/docs/javascripts/katex.js
+++ b/docs/javascripts/katex.js
@@ -1,0 +1,10 @@
+document$.subscribe(({ body }) => {
+  renderMathInElement(body, {
+    delimiters: [
+      { left: "$$", right: "$$", display: true },
+      { left: "$", right: "$", display: false },
+      { left: "\\(", right: "\\)", display: false },
+      { left: "\\[", right: "\\]", display: true },
+    ],
+  });
+});

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -1,27 +1,9 @@
 # API Reference
 
-## AttackModel
+torchattack provides, besides [the attacks](../attacks/index.md) themselves, a set of tools to aid research. Here are these modules and their API.
 
 ::: torchattack.attack_model.AttackModel
-    options:
-        heading_level: 3
-
-## create_attack
 
 ::: torchattack.create_attack.create_attack
-    options:
-        heading_level: 3
 
-## The `eval` module
-
-### Dataloader
-
-::: torchattack.eval.dataset.NIPSLoader
-    options:
-        heading_level: 4
-
-### Metric
-
-::: torchattack.eval.metric.FoolingRateMetric
-    options:
-        heading_level: 3
+::: torchattack.eval

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -1,0 +1,27 @@
+# API Reference
+
+## AttackModel
+
+::: torchattack.attack_model.AttackModel
+    options:
+        heading_level: 3
+
+## create_attack
+
+::: torchattack.create_attack.create_attack
+    options:
+        heading_level: 3
+
+## The `eval` module
+
+### Dataloader
+
+::: torchattack.eval.dataset.NIPSLoader
+    options:
+        heading_level: 4
+
+### Metric
+
+::: torchattack.eval.metric.FoolingRateMetric
+    options:
+        heading_level: 3

--- a/docs/usage/attack-creation.md
+++ b/docs/usage/attack-creation.md
@@ -1,6 +1,84 @@
 # Creating and running an attack
 
-## API
+After [setting up a pretrained model](./attack-model.md), we can now create an attack.
+
+## Importing the attack class
+
+Attacks in torchattack are exposed as classes.
+
+To create the classic attack — Fast Gradient Sign Method ([FGSM](../attacks/fgsm.md)), for instance, we can import the `FGSM` class from torchattack.
+
+```python hl_lines="2 8"
+import torch
+from torchattack import AttackModel, FGSM
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = AttackModel.from_pretrained(model_name='resnet50', device=device)
+transform, normalize = model.transform, model.normalize
+
+attack = FGSM(model, normalize, device)
+```
+
+!!! info "Note the three arguments, `model`, `normalize`, and `device`."
+
+    - `model` specifies the pretrained model to attack, often acting as the surrogate model for transferable black-box attacks.
+    - `normalize` is the normalize function associated with the model's weight, that we automatically resolved earlier.
+    - `device` is the device to run the attack on.
+
+    All attacks in torchattack, if not explicitly stated, require these three arguments. (1)
+    { .annotate }
+
+    1. This is the [*thin layer of abstraction*](./index.md) that we were talking about.
+
+Most adversarial attacks, especially gradient-based attacks, are projected onto the $\ell_p$ ball, where $p$ is the norm, to restrict the magnitude of the perturbation and maintain imperceptibility.
+
+Attacks like FGSM takes an additional argument, `eps`, to specify the radius $\varepsilon$ of the $\ell_\infty$ ball.
+
+For an 8-bit image with pixel values in the range of $[0, 255]$, the tensor represented image is within $[0, 1]$ (after division by 255). **As such, common values for `eps` are `8/255` or `16/255`, or simply `0.03`.**
+
+```python
+attack = FGSM(model, normalize, device, eps=8 / 255)
+```
+
+Different attacks hold different arguments. For instance, the Momentum-Iterative FGSM ([MI-FGSM](../attacks/mifgsm.md)) attack accepts the additional `steps` and `decay` as arguments.
+
+```python
+from torchattack import MIFGSM
+
+attack = MIFGSM(model, normalize, device, eps=8 / 255, steps=10, decay=1.0)
+```
+
+Finally, please take a look at the actual implementation of FGSM here :octicons-arrow-right-24: [`torchattack.FGSM`][torchattack.FGSM] (expand collapsed `fgsm.py` source code).
+
+## The `create_attack()` method
+
+torchattack provides an additional helper to create attacks by its name.
+
+```python
+from torchattack import create_attack
+```
+
+To initialize the same FGSM attack.
+
+```python
+attack = create_attack('FGSM', model, normalize, device)
+```
+
+To specify the common `eps` argument.
+
+```python
+attack = create_attack('FGSM', model, normalize, device, eps=8 / 255)
+```
+
+For additional attack specific arguments, pass them as keyword arguments.
+
+```python
+attack = create_attack('MIFGSM', model, normalize, device, eps=8 / 255, steps=10, decay=1.0)
+```
+
+## Running the attack
+
+## API Reference
 
 ::: torchattack.create_attack.create_attack
     options:

--- a/docs/usage/attack-creation.md
+++ b/docs/usage/attack-creation.md
@@ -50,9 +50,9 @@ attack = MIFGSM(model, normalize, device, eps=8 / 255, steps=10, decay=1.0)
 
 Finally, please take a look at the actual implementation of FGSM here :octicons-arrow-right-24: [`torchattack.FGSM`][torchattack.FGSM] (expand collapsed `fgsm.py` source code).
 
-## The `create_attack()` method
+## The `create_attack` method
 
-torchattack provides an additional helper to create attacks by its name.
+torchattack provides an additional helper, [`create_attack`][torchattack.create_attack.create_attack], to create an attack by its name.
 
 ```python
 from torchattack import create_attack
@@ -76,10 +76,29 @@ For additional attack specific arguments, pass them as keyword arguments.
 attack = create_attack('MIFGSM', model, normalize, device, eps=8 / 255, steps=10, decay=1.0)
 ```
 
+For generative attacks ([BIA](../attacks/bia.md), [CDA](../attacks/cda.md), and [LTP](../attacks/ltp.md), etc.) that do not require passing the `model` and `normalize` arguments.
+
+```python
+attack = create_attack('BIA', device, eps=10 / 255, weights='DEFAULT')
+attack = create_attack('CDA', device, eps=10 / 255, checkpoint_path='path/to/checkpoint.pth')
+```
+
+!!! tip "Generative attacks are models specifically trained to generate adversarial perturbation directly."
+
+    These models have already been given a pretrained model to attack, which acts as the discriminator in their setups. In inference mode, they load checkpoints like any other pretrained model from torchvision. **The checkpoints provided by torchattack are sourced from their original repositories.**
+
 ## Running the attack
 
-## API Reference
+Similar to PyTorch models, torchattack attacks implement the `forward` method, to run the attack on a batch of images.
 
-::: torchattack.create_attack.create_attack
-    options:
-        heading_level: 3
+Calling the attack class itself also directs to the `forward` method.
+
+Here is a simple example for a batch of dummy images of shape $(4, 3, 224, 224)$ (typical ImageNet images), and their corresponding labels (1000 classes).
+
+```python
+x = torch.rand(4, 3, 224, 224).to(device)
+y = torch.randint(0, 1000, (4,)).to(device)
+
+x_adv = attack(x, y)
+# x_adv is the generated adversarial example
+```

--- a/docs/usage/attack-evaluation.md
+++ b/docs/usage/attack-evaluation.md
@@ -1,11 +1,70 @@
 # Loading a dataset and running evaluations
 
-## API
+To run an attack on actual images, we would normally use a dataloader, just like loading any other dataset.
 
-::: torchattack.eval.dataset
-    options:
-        heading_level: 3
+## Loading the NIPS 2017 dataset
 
-::: torchattack.eval.metric
-    options:
-        heading_level: 3
+One of the most common datasets used in evaluating adversarial transferability is the [NIPS 2017 Adversarial Learning challenges](https://www.kaggle.com/datasets/google-brain/nips-2017-adversarial-learning-development-set) dataset. The dataset contains 1000 images from the ImageNet validation set and is widely used in current state-of-the-art transferable adversarial attack research.
+
+torchattack provides the [`NIPSLoader`][torchattack.eval.NIPSLoader] to load this dataset.
+
+Provided that we have downloaded the dataset under `datasets/nips2017` with the following file structure.
+
+```tree
+datasets/nips2017
+├── images
+│   ├── 000b7d55b6184b08.png
+│   ├── 001b5e6f1b89fd3b.png
+│   ├── 00312c7e7196baf4.png
+│   ├── 00c3cd597f1ee96f.png
+│   ├── ...
+│   └── fff35cdcce3cde43.png
+├── categories.csv
+└── images.csv
+```
+
+We can load the dataset like so.
+
+```python hl_lines="3 9"
+import torch
+from torchattack import AttackModel, FGSM
+from torchattack.eval import NIPSLoader
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = AttackModel.from_pretrained(model_name='resnet50', device=device)
+transform, normalize = model.transform, model.normalize
+
+dataloader = NIPSLoader(root='datasets/nips2017', transform=transform, batch_size=16)
+
+attack = FGSM(model, normalize, device)
+```
+
+And wrap the dataloader in the progress bar of your choice, [such as rich](https://rich.readthedocs.io/en/stable/progress.html).
+
+```python
+from rich.progress import track
+
+dataloader = track(dataloader, description='Evaluating attack')
+```
+
+## Running the attack
+
+When iterated over, the [`NIPSLoader`][torchattack.eval.NIPSLoader] returns a tuple of `(x, y, fname)`, where
+
+- `x` is the batch of images,
+- `y` is the batch of labels,
+- and `fname` is the batch of filenames useful for saving the generated adversarial examples if needed.
+
+We can now run the attack by iterating over the dataset.
+
+```python
+for x, y, fname in dataloader:
+    x, y = x.to(device), y.to(device)
+    x_adv = attack(x, y)
+```
+
+## Evaluating the attack
+
+How would we know if the attack was successful?
+
+We can evaluate the attack's fooling rate, by comparing the model's accuracy on clean samples and their associated adversarial examples.

--- a/docs/usage/attack-model.md
+++ b/docs/usage/attack-model.md
@@ -31,30 +31,38 @@ The [`AttackModel.from_pretrained()`][torchattack.attack_model.AttackModel.from_
 2. It sets the model to evaluation mode by calling `model.eval()`, and moves the model to the specified device.
 3. It resolves the model's `transform` and `normalize` functions associated with its pretrained weights to the `AttackModel` instance, also automatically.
 
-Doing so, we not only get the pretrained model set up, but also **its necessary associated, and more importantly, ==separated== transform and normalization functions.**
+Doing so, we not only get our pretrained model set up, but also its necessary associated, and more importantly, **==_separated_ transform and normalization functions==(1).**
+{ .annotate }
+
+1. Separating the model's normalize function from its transform is crucial for launching attacks, **as adversarial perturbation is crafted within the original image space — most often within `(0, 1)`.**
 
 ```python
 transform, normalize = model.transform, model.normalize
 ```
 
-<!-- Load a pretrained model to attack from either torchvision or timm.
+## Specifying the model source
+
+`AttackModel` honors an explicit model source to load from, by prepending the model name with `tv/` or `timm/`, for `torchvision` and `timm` respectively.
+
+For instance, to load the ViT-B/16 model from `timm`.
 
 ```python
-from torchattack import AttackModel
-
-# Load a model with `AttackModel`
-model = AttackModel.from_pretrained(model_name='resnet50', device=device)
-# `AttackModel` automatically attach the model's `transform` and `normalize` functions
-transform, normalize = model.transform, model.normalize
-
-# Additionally, to explicitly specify where to load the pretrained model from (timm or torchvision),
-# prepend the model name with 'timm/' or 'tv/' respectively, or use the `from_timm` argument, e.g.
 vit_b16 = AttackModel.from_pretrained(model_name='timm/vit_base_patch16_224', device=device)
-inv_v3 = AttackModel.from_pretrained(model_name='tv/inception_v3', device=device)
-pit_b = AttackModel.from_pretrained(model_name='pit_b_224', device=device, from_timm=True)
-``` -->
+```
 
-## API
+To load the Inception-v3 model from `torchvision`.
+
+```python
+inv_v3 = AttackModel.from_pretrained(model_name='tv/inception_v3', device=device)
+```
+
+Or, explicitly specify using `timm` as the source with `from_timm=True`.
+
+```python
+pit_b = AttackModel.from_pretrained(model_name='pit_b_224', device=device, from_timm=True)
+```
+
+## API Reference
 
 ::: torchattack.attack_model.AttackModel
     options:

--- a/docs/usage/attack-model.md
+++ b/docs/usage/attack-model.md
@@ -1,14 +1,58 @@
 # Loading pretrained models
 
-```python
-import torch
-from torchattack import AttackModel
-```
+## The `AttackModel`
 
 To launch any adversarial attack, you would need a model to attack.
 
 torchattack provides a simple abstraction over both [torchvision](https://github.com/pytorch/vision) and [timm](https://github.com/huggingface/pytorch-image-models) models, to load pretrained image classification models on ImageNet.
 
+First, import `torch`, import `AttackModel` from `torchattack`, and determine the device to use.
+
+```python
+import torch
+from torchattack import AttackModel
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+```
+
+## Pretrained models are loaded by its name
+
+Contrary to `torchvision.models`, `AttackModel` loads a pretrained model by its name.
+
+To load a ResNet-50 model for instance.
+
+```python
+model = AttackModel.from_pretrained(model_name='resnet50', device=device)
+```
+
+The [`AttackModel.from_pretrained()`][torchattack.attack_model.AttackModel.from_pretrained] method does three things under the hood:
+
+1. It automatically loads the model from either `torchvision` (by default) or `timm` (if not found in `torchvision`).
+2. It sets the model to evaluation mode by calling `model.eval()`, and moves the model to the specified device.
+3. It resolves the model's `transform` and `normalize` functions associated with its pretrained weights to the `AttackModel` instance, also automatically.
+
+Doing so, we not only get the pretrained model set up, but also **its necessary associated, and more importantly, ==separated== transform and normalization functions.**
+
+```python
+transform, normalize = model.transform, model.normalize
+```
+
+<!-- Load a pretrained model to attack from either torchvision or timm.
+
+```python
+from torchattack import AttackModel
+
+# Load a model with `AttackModel`
+model = AttackModel.from_pretrained(model_name='resnet50', device=device)
+# `AttackModel` automatically attach the model's `transform` and `normalize` functions
+transform, normalize = model.transform, model.normalize
+
+# Additionally, to explicitly specify where to load the pretrained model from (timm or torchvision),
+# prepend the model name with 'timm/' or 'tv/' respectively, or use the `from_timm` argument, e.g.
+vit_b16 = AttackModel.from_pretrained(model_name='timm/vit_base_patch16_224', device=device)
+inv_v3 = AttackModel.from_pretrained(model_name='tv/inception_v3', device=device)
+pit_b = AttackModel.from_pretrained(model_name='pit_b_224', device=device, from_timm=True)
+``` -->
 
 ## API
 

--- a/docs/usage/attack-model.md
+++ b/docs/usage/attack-model.md
@@ -6,7 +6,7 @@ To launch any adversarial attack, you would need a model to attack.
 
 torchattack provides a simple abstraction over both [torchvision](https://github.com/pytorch/vision) and [timm](https://github.com/huggingface/pytorch-image-models) models, to load pretrained image classification models on ImageNet.
 
-First, import `torch`, import `AttackModel` from `torchattack`, and determine the device to use.
+First, import `torch`, import [`AttackModel`][torchattack.attack_model.AttackModel] from `torchattack`, and determine the device to use.
 
 ```python
 import torch
@@ -17,7 +17,7 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 ## Pretrained models are loaded by its name
 
-Contrary to `torchvision.models`, `AttackModel` loads a pretrained model by its name.
+Contrary to `torchvision.models`, [`AttackModel`][torchattack.attack_model.AttackModel] loads a pretrained model by its name.
 
 To load a ResNet-50 model for instance.
 
@@ -29,7 +29,7 @@ The [`AttackModel.from_pretrained()`][torchattack.attack_model.AttackModel.from_
 
 1. It automatically loads the model from either `torchvision` (by default) or `timm` (if not found in `torchvision`).
 2. It sets the model to evaluation mode by calling `model.eval()`, and moves the model to the specified device.
-3. It resolves the model's `transform` and `normalize` functions associated with its pretrained weights to the `AttackModel` instance, also automatically.
+3. It resolves the model's `transform` and `normalize` functions associated with its pretrained weights to the [`AttackModel`][torchattack.attack_model.AttackModel] instance, also automatically.
 
 Doing so, we not only get our pretrained model set up, but also its necessary associated, and more importantly, **==_separated_ transform and normalization functions==(1).**
 { .annotate }
@@ -42,7 +42,7 @@ transform, normalize = model.transform, model.normalize
 
 ## Specifying the model source
 
-`AttackModel` honors an explicit model source to load from, by prepending the model name with `tv/` or `timm/`, for `torchvision` and `timm` respectively.
+[`AttackModel`][torchattack.attack_model.AttackModel] honors an explicit model source to load from, by prepending the model name with `tv/` or `timm/`, for `torchvision` and `timm` respectively.
 
 For instance, to load the ViT-B/16 model from `timm`.
 
@@ -61,9 +61,3 @@ Or, explicitly specify using `timm` as the source with `from_timm=True`.
 ```python
 pit_b = AttackModel.from_pretrained(model_name='pit_b_224', device=device, from_timm=True)
 ```
-
-## API Reference
-
-::: torchattack.attack_model.AttackModel
-    options:
-        heading_level: 3

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -19,6 +19,9 @@ title: Usage
     <figcaption markdown>[TGR](../attacks/tgr.md) :octicons-arrow-right-24: ViT-B/16</figcaption>
 </figure>
 </div>
+
+## Introduction
+
 **Adversarial examples** are tricky inputs designed to confuse machine learning models.
 
 In vision tasks like image classification, these examples are created by slightly altering an original image. The changes are so small that humans can't really notice them, yet **they can cause significant shifts in the model's prediction.**
@@ -33,6 +36,8 @@ torchattack is a library for PyTorch that offers a collection of state-of-the-ar
 Attacks in torchattack are implemented over a thin layer of abstraction (`torchattack._attack.Attack`), with minimal changes to the original implementation within its research paper, along with comprehensive type hints and explanatory comments, to make it easy for researchers like me and you to use and understand.
 
 The library also provides tools to load pretrained models, set up attacks, and run tests.
+
+## Getting Started
 
 To get started, follow the links below:
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -3,28 +3,34 @@ title: Usage
 ---
 
 !!! danger
-    This section of the documentation is still under construction. Please check back later for updates.
-
-**Adversarial examples** are tricky inputs designed to confuse machine learning models.
-
-In vision tasks like image classification, these examples are created by slightly altering an original image. The changes are so small that humans can't really notice them, yet they can cause significant shifts in the model's prediction.
+    Under construction. Please check back later.
 
 <div markdown style="display: flex; justify-content: space-around;">
 <figure markdown="span">
-    ![Benign image](../images/usage/xs.png){ width=240 }
+    ![Benign image](../images/usage/xs.png){ width=200 }
     <figcaption>Benign Image</figcaption>
 </figure>
 <figure markdown="span">
-    ![Adversarial example via MI-FGSM](../images/usage/advs-mifgsm-resnet50-eps-8.png){ width=240 }
+    ![Adversarial example via MI-FGSM](../images/usage/advs-mifgsm-resnet50-eps-8.png){ width=200 }
     <figcaption markdown>[MIFGSM](../attacks/mifgsm.md) :octicons-arrow-right-24: ResNet50</figcaption>
 </figure>
 <figure markdown="span">
-    ![Adversarial example via TGR](../images/usage/advs-tgr-vitb16-eps-8.png){ width=240 }
+    ![Adversarial example via TGR](../images/usage/advs-tgr-vitb16-eps-8.png){ width=200 }
     <figcaption markdown>[TGR](../attacks/tgr.md) :octicons-arrow-right-24: ViT-B/16</figcaption>
 </figure>
 </div>
+**Adversarial examples** are tricky inputs designed to confuse machine learning models.
 
-torchattack is a library for PyTorch that offers a variety of state-of-the-art attacks to create these adversarial examples. **It focuses on transferable black-box attacks on image classification models.** The attacks are implemented over a thin abstraction layer (`torchattack._attack.Attack`), with minimal changes to the original research paper, along with comprehensive type hints and comments, to make it easy for researchers like you and me to use and understand.
+In vision tasks like image classification, these examples are created by slightly altering an original image. The changes are so small that humans can't really notice them, yet **they can cause significant shifts in the model's prediction.**
+
+torchattack is a library for PyTorch that offers a collection of state-of-the-art attacks to create these adversarial examples. **It focuses on transferable (1) black-box (2) attacks on image classification models.**
+{ .annotate }
+
+1. **_Transferable adversarial attacks_** are designed to fool multiple models, most often the more the better, not just the specific one they were initially created for. This means an attack effective on one model might also work on others.
+
+2. **_Black-box attacks_** are attacks that don't require access to the model's internal parameters. Instead, they rely only on the model's inputs and outputs to launch the attack.
+
+Attacks in torchattack are implemented over a thin layer of abstraction (`torchattack._attack.Attack`), with minimal changes to the original implementation within its research paper, along with comprehensive type hints and explanatory comments, to make it easy for researchers like me and you to use and understand.
 
 The library also provides tools to load pretrained models, set up attacks, and run tests.
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,9 +1,4 @@
----
-title: Usage
----
-
-!!! danger
-    Under construction. Please check back later.
+# Introduction
 
 <div markdown style="display: flex; justify-content: space-around;">
 <figure markdown="span">
@@ -20,7 +15,7 @@ title: Usage
 </figure>
 </div>
 
-## Introduction
+## Adversarial examples
 
 **Adversarial examples** are tricky inputs designed to confuse machine learning models.
 
@@ -44,6 +39,6 @@ To get started, follow the links below:
 - [Loading pretrained models and important attributes](./attack-model.md)
 - [Creating and running attacks](./attack-creation.md)
 - [Loading a dataset and running evaluations](./attack-evaluation.md)
-- [A full example to evaluate transferability](./runner.md)
+- [A full example to evaluate transferability](./api-reference.md)
 
 Or dive straight into [all available attacks](../attacks/index.md).

--- a/docs/usage/putting-it-all-together.md
+++ b/docs/usage/putting-it-all-together.md
@@ -1,0 +1,52 @@
+# Putting it all together
+
+For transferable black-box attacks, we would often initialize more than one model, assigning the models other than the one being directly attacked as black-box victim models, to evaluate the transferability of the attack _(the attack's effectiveness under a black-box scenario where the target victim model's internal workings are unknown to the attacker)_.
+
+## A full example
+
+To put everything together, we show a full example that does the following.
+
+1. Load the NIPS 2017 dataset.
+2. Initialize a pretrained ResNet-50, as the white-box surrogate model, for creating adversarial examples.
+3. Initialize another pretrained VGG-19, as the black-box victim model, to evaluate adversarial transferability.
+4. Run the classic MI-FGSM attack, and demonstrate its performance.
+
+```python title="examples/mifgsm_transfer.py"
+--8<-- "examples/mifgsm_transfer.py"
+```
+
+```console
+$ python examples/mifgsm_transfer.py
+Evaluating attack ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:47
+White-box (ResNet-50): 95.10% -> 0.10% (FR: 99.89%)
+Black-box (VGG-19): 89.10% -> 61.00% (FR: 31.54%)
+```
+
+## Attack Runner
+
+torchattack provides a simple command line runner at `torchattack.eval.runner`, and the function [`run_attack`][torchattack.eval.run_attack], to evaluate the transferability of attacks. The runner itself also acts as a full example to demonstrate how researchers like us can use torchattack to create and evaluate adversarial transferability.
+
+An exhaustive example :octicons-arrow-right-24: run the [`PGD`](../attacks/pgd.md) attack,
+
+- with an epsilon constraint of 16/255,
+- on the ResNet-18 model as the white-box surrogate model,
+- transferred to the VGG-11, DenseNet-121, and Inception-V3 models as the black-box victim models,
+- on the NIPS 2017 dataset,
+- with a maximum of 200 samples and a batch size of 4,
+
+```console
+$ python -m torchattack.eval.runner \
+    --attack PGD \
+    --eps 16/255 \
+    --model-name resnet18 \
+    --victim-model-names vgg11 densenet121 inception_v3 \
+    --dataset-root datasets/nips2017 \
+    --max-samples 200 \
+    --batch-size 4
+PGD(model=ResNet, device=cuda, normalize=Normalize, eps=0.063, alpha=None, steps=10, random_start=True, clip_min=0.000, clip_max=1.000, targeted=False, lossfn=CrossEntropyLoss())
+Attacking ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:07
+Surrogate (resnet18): cln_acc=81.50%, adv_acc=0.00% (fr=100.00%)
+Victim (vgg11): cln_acc=76.50%, adv_acc=33.00% (fr=56.86%)
+Victim (densenet121): cln_acc=87.00%, adv_acc=37.00% (fr=57.47%)
+Victim (inception_v3): cln_acc=78.50%, adv_acc=56.00% (fr=28.66%)
+```

--- a/docs/usage/runner.md
+++ b/docs/usage/runner.md
@@ -1,9 +1,0 @@
-# Full Example
-
-## Attack Runner
-
-torchattack provides a simple command line runner to create and evaluate attacks.
-
-The runner itself also acts as a full example to demonstrate how researchers like you can use torchattack to create and evaluate attacks.
-
-::: torchattack.eval.runner

--- a/examples/mifgsm_transfer.py
+++ b/examples/mifgsm_transfer.py
@@ -1,0 +1,43 @@
+import torch
+from rich.progress import track
+
+from torchattack import MIFGSM, AttackModel
+from torchattack.eval import FoolingRateMetric, NIPSLoader
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+# Initialize the white-box model
+model = AttackModel.from_pretrained(model_name='resnet50', device=device)
+transform, normalize = model.transform, model.normalize
+
+# Initialize the attacker MI-FGSM
+attacker = MIFGSM(model, normalize, device, eps=8 / 255)
+
+# Load the dataset
+dataloader = NIPSLoader(root='datasets/nips2017', transform=transform, batch_size=16)
+
+# Initialize the black-box victim model (vmodel)
+vmodel = AttackModel.from_pretrained(model_name='vgg19', device=device)
+# Track both white-box and black-box fooling rates
+frm, vfrm = (FoolingRateMetric(), FoolingRateMetric())
+
+# Attack loop
+for x, y, _ in track(dataloader, description='Evaluating attack'):
+    x, y = x.to(device), y.to(device)
+    x_adv = attacker(x, y)
+
+    # Track fooling rate
+    x_outs = model(normalize(x))
+    adv_outs = model(normalize(x_adv))
+    frm.update(y, x_outs, adv_outs)
+
+    # Track black-box fooling rate
+    vx_outs = vmodel(vmodel.normalize(x))
+    vadv_outs = vmodel(vmodel.normalize(x_adv))
+    vfrm.update(y, vx_outs, vadv_outs)
+
+# Show evaluation results
+cln_acc, adv_acc, fr = frm.compute()
+vcln_acc, vadv_acc, vfr = vfrm.compute()
+print(f'White-box (ResNet-50): {cln_acc:.2%} -> {adv_acc:.2%} (FR: {fr:.2%})')
+print(f'Black-box (VGG-19): {vcln_acc:.2%} -> {vadv_acc:.2%} (FR: {vfr:.2%})')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - usage/attack-creation.md
       - usage/attack-evaluation.md
       - usage/runner.md
+      - usage/api-reference.md
   - ...
   - development.md
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,11 +7,11 @@ copyright: Copyright &copy; 2023-Present Spencer Woo
 nav:
   - index.md
   - Usage:
-    - usage/index.md
-    - usage/attack-model.md
-    - usage/attack-creation.md
-    - usage/attack-evaluation.md
-    - usage/runner.md
+      - usage/index.md
+      - usage/attack-model.md
+      - usage/attack-creation.md
+      - usage/attack-evaluation.md
+      - usage/runner.md
   - ...
   - development.md
 theme:
@@ -57,25 +57,38 @@ theme:
     - content.tabs.link
 extra_css:
   - stylesheets/extra.css
+  - https://unpkg.com/katex@0/dist/katex.min.css
+extra_javascript:
+  - javascripts/katex.js
+  - https://unpkg.com/katex@0/dist/katex.min.js
+  - https://unpkg.com/katex@0/dist/contrib/auto-render.min.js
 markdown_extensions:
   - abbr
   - admonition
-  - pymdownx.details
-  - pymdownx.superfences
   - attr_list
   - def_list
   - footnotes
   - md_in_html
   - toc:
       permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
   - pymdownx.critic
   - pymdownx.caret
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.tilde
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.arithmatex:
+      generic: true
 plugins:
   - search
   - gen-files:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
       - usage/attack-model.md
       - usage/attack-creation.md
       - usage/attack-evaluation.md
-      - usage/runner.md
+      - usage/putting-it-all-together.md
       - usage/api-reference.md
   - ...
   - development.md
@@ -39,21 +39,21 @@ theme:
         name: Switch to system preference
   features:
     - navigation.tracking
+    - navigation.path
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
     - navigation.tabs
     - navigation.top
     - navigation.sections
     - navigation.prune
     - navigation.footer
     - toc.follow
-    - toc.integrate
+    # - toc.integrate
     - search.suggest
     - content.action.edit
     - content.code.copy
-    - navigation.path
-    - navigation.instant
-    - navigation.instant.prefetch
-    - navigation.instant.progress
-    - navigation.indexes
+    # - navigation.indexes
     - content.code.annotate
     - content.tabs.link
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,11 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
+  - pymdownx.critic
+  - pymdownx.caret
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.tilde
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg

--- a/tests/test_create_attack.py
+++ b/tests/test_create_attack.py
@@ -6,7 +6,7 @@ from torchattack import create_attack
 
 @pytest.mark.parametrize(
     ('attack_name', 'expected'),
-    [i for i in torchattack.GRADIENT_NON_VIT_ATTACKS.items() if i[0] != 'DR'],
+    [kv for kv in torchattack.GRADIENT_NON_VIT_ATTACKS.items() if kv[0] != 'DR'],
 )
 def test_create_non_vit_attack_same_as_imported(
     attack_name,
@@ -18,10 +18,7 @@ def test_create_non_vit_attack_same_as_imported(
     assert created_attacker == expected_attacker
 
 
-def test_create_dr_attack_same_as_imported(
-    vgg16_model,
-    data,
-):
+def test_create_dr_attack_same_as_imported(vgg16_model):
     created_attacker = create_attack('DR', vgg16_model)
     expected_attacker = torchattack.DR(vgg16_model)
     assert created_attacker == expected_attacker
@@ -51,100 +48,50 @@ def test_create_generative_attack_same_as_imported(attack_name, expected):
 
 def test_create_attack_with_eps(device, resnet50_model):
     eps = 0.3
-    attack_args = {}
     attacker = create_attack(
         attack='FGSM',
         model=resnet50_model,
         normalize=resnet50_model.normalize,
         device=device,
         eps=eps,
-        attack_args=attack_args,
     )
     assert attacker.eps == eps
 
 
-def test_create_attack_with_attack_args_eps(device, resnet50_model):
-    attack_args = {'eps': 0.1}
+def test_create_attack_with_extra_args(device, resnet50_model):
+    attack_args = {'eps': 0.1, 'steps': 40, 'alpha': 0.01, 'decay': 0.9}
     attacker = create_attack(
-        attack='FGSM',
+        attack='MIFGSM',
         model=resnet50_model,
         normalize=resnet50_model.normalize,
         device=device,
-        attack_args=attack_args,
+        **attack_args,
     )
     assert attacker.eps == attack_args['eps']
-
-
-def test_create_attack_with_both_eps_and_attack_args(device, resnet50_model):
-    eps = 0.3
-    attack_args = {'eps': 0.1}
-    with pytest.warns(
-        UserWarning,
-        match="The 'eps' value provided as an argument will overwrite the existing "
-        "'eps' value in 'attack_args'. This MAY NOT be the intended behavior.",
-    ):
-        attacker = create_attack(
-            attack='FGSM',
-            model=resnet50_model,
-            normalize=resnet50_model.normalize,
-            device=device,
-            eps=eps,
-            attack_args=attack_args,
-        )
-    assert attacker.eps == eps
-
-
-def test_create_attack_with_both_weights_and_attack_args(device):
-    weights = 'VGG19_IMAGENET'
-    attack_args = {'weights': 'VGG19_IMAGENET'}
-    with pytest.warns(
-        UserWarning,
-        match="The 'weights' value provided as an argument will "
-        "overwrite the existing 'weights' value in 'attack_args'. "
-        'This MAY NOT be the intended behavior.',
-    ):
-        attacker = create_attack(
-            attack='CDA',
-            device=device,
-            weights=weights,
-            attack_args=attack_args,
-        )
-    assert attacker.weights == weights
+    assert attacker.steps == attack_args['steps']
+    assert attacker.alpha == attack_args['alpha']
+    assert attacker.decay == attack_args['decay']
 
 
 def test_create_attack_with_invalid_eps(device, resnet50_model):
-    eps = 0.3
-    with pytest.warns(
-        UserWarning, match="argument 'eps' is invalid in DeepFool and will be ignored."
-    ):
-        attacker = create_attack(
+    with pytest.raises(TypeError):
+        create_attack(
             attack='DeepFool',
             model=resnet50_model,
             normalize=resnet50_model.normalize,
             device=device,
-            eps=eps,
+            eps=0.03,
         )
-    assert 'eps' not in attacker.__dict__
 
 
-def test_create_attack_with_weights_and_checkpoint_path(device):
+def test_create_attack_cda_with_weights(device):
     weights = 'VGG19_IMAGENET'
-    checkpoint_path = 'path/to/checkpoint'
-    attack_args = {}
-    with pytest.warns(
-        UserWarning,
-        match="argument 'weights' and 'checkpoint_path' are only used for "
-        "generative attacks, and will be ignored for 'FGSM'.",
-    ):
-        attacker = create_attack(
-            attack='FGSM',
-            device=device,
-            weights=weights,
-            checkpoint_path=checkpoint_path,
-            attack_args=attack_args,
-        )
-    assert 'weights' not in attacker.__dict__
-    assert 'checkpoint_path' not in attacker.__dict__
+    attacker = create_attack(
+        attack='CDA',
+        device=device,
+        weights=weights,
+    )
+    assert attacker.weights == weights
 
 
 def test_create_attack_with_invalid_attack_name(device, resnet50_model):

--- a/torchattack/__init__.py
+++ b/torchattack/__init__.py
@@ -27,7 +27,7 @@ from torchattack.vdc import VDC
 from torchattack.vmifgsm import VMIFGSM
 from torchattack.vnifgsm import VNIFGSM
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 __all__ = [
     # Helper function to create an attack by its name

--- a/torchattack/create_attack.py
+++ b/torchattack/create_attack.py
@@ -25,9 +25,7 @@ def create_attack(
         normalize: The normalization function specific to the model. Defaults to None.
         device: The device on which the attack will be executed. Defaults to None.
         eps: The epsilon value for the attack. Defaults to None.
-        weights: The name of the generator weight for generative attacks. Defaults to 'DEFAULT'.
-        checkpoint_path: The path to the checkpoint file for generative attacks. Defaults to None.
-        attack_args: Additional config parameters for the attack. Defaults to None.
+        kwargs: Additional config parameters for the attack. Defaults to None.
 
     Returns:
         Attack: An instance of the specified attack.

--- a/torchattack/create_attack.py
+++ b/torchattack/create_attack.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -8,28 +8,14 @@ from torchattack._attack import Attack
 from torchattack.attack_model import AttackModel
 
 
-def attack_warn(message: str) -> None:
-    from warnings import warn
-
-    warn(message, category=UserWarning, stacklevel=2)
-
-
-def attack_arg_override_warn(arg_name: str) -> None:
-    attack_warn(
-        f"The '{arg_name}' value provided as an argument will overwrite the existing "
-        f"'{arg_name}' value in 'attack_args'. This MAY NOT be the intended behavior."
-    )
-
-
 def create_attack(
     attack: Union['Attack', str],
-    model: Union[nn.Module, AttackModel, None] = None,
-    normalize: Union[Callable[[torch.Tensor], torch.Tensor], None] = None,
-    device: Union[torch.device, None] = None,
-    eps: Union[float, None] = None,
-    weights: Union[str, None] = 'DEFAULT',
-    checkpoint_path: Union[str, None] = None,
-    attack_args: Union[dict[str, Any], None] = None,
+    model: Optional[Union[nn.Module, AttackModel]] = None,
+    normalize: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+    device: Optional[torch.device] = None,
+    *,
+    eps: Optional[float] = None,
+    **kwargs: Any,
 ) -> Attack:
     """Create a torchattack instance based on the provided attack name and config.
 
@@ -39,74 +25,42 @@ def create_attack(
         normalize: The normalization function specific to the model. Defaults to None.
         device: The device on which the attack will be executed. Defaults to None.
         eps: The epsilon value for the attack. Defaults to None.
-        weights: The name of the generator weight for generative attacks. Defaults to 'DEFAULT'.
-        checkpoint_path: The path to the checkpoint file for generative attacks. Defaults to None.
-        attack_args: Additional config parameters for the attack. Defaults to None.
+        **attack_kwargs: Additional keyword arguments as parameters for the attack.
 
     Returns:
         Attack: An instance of the specified attack.
 
     Raises:
         ValueError: If the specified attack name is not supported within torchattack.
-
-    Notes:
-        - If `eps` is provided and also present in `attack_args`, a warning will be
-          issued and the value in `attack_args` will be overwritten.
-        - For certain attacks like 'GeoDA' and 'DeepFool', the `eps` parameter is
-          invalid and will be ignored if present in `attack_args`.
-        - The `weights` and `checkpoint_path` parameters are only used for generative attacks.
     """
-
-    if attack_args is None:
-        attack_args = {}
 
     # Determine attack name and check if it is supported
     attack_name = attack if isinstance(attack, str) else attack.__name__  # type: ignore[attr-defined]
     if attack_name not in torchattack.SUPPORTED_ATTACKS:
         raise ValueError(f"Attack '{attack_name}' is not supported within torchattack.")
-    attack_cls: 'Attack' = (
+    # Get attack class if passed as a string
+    attack_cls = (
         getattr(torchattack, attack_name) if isinstance(attack, str) else attack
     )
 
-    # Check if eps is provided and overwrite the value in attack_args if present
+    # `eps` is explicitly set as it is such a common argument
+    # All other arguments should be passed as keyword arguments
     if eps is not None:
-        if 'eps' in attack_args:
-            attack_arg_override_warn('eps')
-        attack_args['eps'] = eps
-
-    # Check if attacks that do not require eps have eps in attack_args
-    if attack_name in torchattack.NON_EPS_ATTACKS and 'eps' in attack_args:
-        attack_warn(f"argument 'eps' is invalid in {attack_name} and will be ignored.")
-        attack_args.pop('eps', None)
-
-    # Check if non-generative attacks have weights or checkpoint_path
-    if attack_name not in torchattack.GENERATIVE_ATTACKS and (
-        weights != 'DEFAULT' or checkpoint_path is not None
-    ):
-        attack_warn(
-            f"argument 'weights' and 'checkpoint_path' are only used for "
-            f"generative attacks, and will be ignored for '{attack_name}'."
-        )
-        attack_args.pop('weights', None)
-        attack_args.pop('checkpoint_path', None)
+        kwargs['eps'] = eps
 
     # Special handling for generative attacks
-    if attack_name in torchattack.GENERATIVE_ATTACKS:
-        if weights != 'DEFAULT':
-            if 'weights' in attack_args:
-                attack_arg_override_warn('weights')
-            attack_args['weights'] = weights
-        if checkpoint_path is not None:
-            if 'checkpoint_path' in attack_args:
-                attack_arg_override_warn('checkpoint_path')
-            attack_args['checkpoint_path'] = checkpoint_path
-        return attack_cls(device, **attack_args)  # type: ignore[no-any-return]
-
-    return attack_cls(model, normalize, device, **attack_args)  # type: ignore[no-any-return]
+    attacker: Attack = (
+        attack_cls(device=device, **kwargs)
+        if attack_name in torchattack.GENERATIVE_ATTACKS
+        else attack_cls(model=model, normalize=normalize, device=device, **kwargs)
+    )
+    return attacker
 
 
 if __name__ == '__main__':
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = AttackModel.from_pretrained('resnet18', device)
-    attacker = create_attack('MIFGSM', model, model.normalize, device)
-    print(attacker)
+    normalize = model.normalize
+    print(create_attack('MIFGSM', model, normalize, device, eps=0.1, steps=40))
+    print(create_attack('CDA', device=device, weights='VGG19_IMAGENET'))
+    print(create_attack('DeepFool', model, normalize, device, num_classes=20))

--- a/torchattack/create_attack.py
+++ b/torchattack/create_attack.py
@@ -25,7 +25,7 @@ def create_attack(
         normalize: The normalization function specific to the model. Defaults to None.
         device: The device on which the attack will be executed. Defaults to None.
         eps: The epsilon value for the attack. Defaults to None.
-        **attack_kwargs: Additional keyword arguments as parameters for the attack.
+        **kwargs: Additional keyword arguments as parameters for the attack.
 
     Returns:
         Attack: An instance of the specified attack.

--- a/torchattack/eval/dataset.py
+++ b/torchattack/eval/dataset.py
@@ -99,10 +99,10 @@ class NIPSLoader(DataLoader):
 
         ```pycon
         >>> from torchvision.transforms import transforms
-        >>> from torchattack.dataset import NIPSLoader
+        >>> from torchattack.eval import NIPSLoader
         >>> transform = transforms.Compose([transforms.Resize([224]), transforms.ToTensor()])
         >>> dataloader = NIPSLoader(
-        >>>     path="data/nips2017", batch_size=16, transform=transform, max_samples=100
+        >>>     path="data/nips2017", transform=transform, batch_size=16, max_samples=100
         >>> )
         ```
 

--- a/torchattack/eval/runner.py
+++ b/torchattack/eval/runner.py
@@ -63,7 +63,7 @@ def run_attack(
 
     # Set up attack and trackers
     frm = FoolingRateMetric()
-    attacker = create_attack(attack, model, normalize, device, attack_args=attack_args)
+    attacker = create_attack(attack, model, normalize, device, **attack_args)
     print(attacker)
 
     # Setup victim models if provided

--- a/torchattack/eval/runner.py
+++ b/torchattack/eval/runner.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import torchattack
+
 
 def run_attack(
     attack: Any,
@@ -118,11 +120,9 @@ def run_attack(
 if __name__ == '__main__':
     import argparse
 
-    import torchattack
-
     parser = argparse.ArgumentParser(description='Run an attack on a model.')
     parser.add_argument('--attack', type=str, required=True)
-    parser.add_argument('--eps', type=float, default=16)
+    parser.add_argument('--eps', type=str, default='16/255')
     parser.add_argument('--weights', type=str, default='DEFAULT')
     parser.add_argument('--checkpoint-path', type=str, default=None)
     parser.add_argument('--model-name', type=str, default='resnet50')
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     attack_args = {}
-    args.eps = args.eps / 255
+    args.eps = eval(args.eps)
     if args.attack not in torchattack.NON_EPS_ATTACKS:  # type: ignore
         attack_args['eps'] = args.eps
     if args.attack in torchattack.GENERATIVE_ATTACKS:  # type: ignore


### PR DESCRIPTION
Enhance documentation for attack creation and evaluation, improve examples, and refactor the `create_attack` function to utilize keyword arguments for better flexibility. Bump the version to 1.2.0.